### PR TITLE
Base: provide `GeometryBasics.mesh(model)` for triangle mesh conversion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Aqua = "0.8.9"
 Distances = "0.7.2, 0.8, 0.9, 0.10"
+GeometryBasics = "0.5.2"
 ImplicitArrays = "0.2"
 IterativeSolvers = "0.8, 0.9"
 JSON3 = "1.11"
@@ -29,10 +30,16 @@ Test = "1.10"
 TestItemRunner = "1"
 julia = "1.10"
 
+[weakdeps]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+
+[extensions]
+GeometryBasicsExt = "GeometryBasics"
+
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Aqua", "Test", "TestItemRunner"]
+test = ["Aqua", "GeometryBasics", "Test", "TestItemRunner"]

--- a/ext/GeometryBasicsExt.jl
+++ b/ext/GeometryBasicsExt.jl
@@ -1,0 +1,19 @@
+module GeometryBasicsExt
+
+import GeometryBasics
+
+using NESSie
+
+function GeometryBasics.mesh(model::Model{T, Triangle{T}}) where T
+    ridx = IdDict(n => i for (i, n) in enumerate(model.nodes))
+
+    points = GeometryBasics.Point{3, T}.(model.nodes)
+    faces = [
+        GeometryBasics.TriangleFace(ridx[elem.v1], ridx[elem.v2], ridx[elem.v3])
+        for elem in model.elements
+    ]
+
+    GeometryBasics.Mesh(points, faces)
+end
+
+end # module

--- a/test/ext/geometrybasicsext.jl
+++ b/test/ext/geometrybasicsext.jl
@@ -1,0 +1,28 @@
+@testitem "GeometryBasicsExt" begin
+    include("../testsetup.jl")
+
+    using GeometryBasics
+
+    @testset "GeometryBasics.mesh" begin
+        for T in testtypes
+            let model = Model{T, NESSie.Triangle{T}}()
+                gbm = GeometryBasics.mesh(model)
+                @test gbm isa GeometryBasics.Mesh{3, T, TriangleFace{Int}}
+                @test isempty(gbm.position)
+                @test isempty(gbm.faces)
+            end
+
+            let model = Format.readoff("../../data/born/na.off", T)
+                nodes = Set((v...,) for v in model.nodes)
+                elems = Set((e.v1..., e.v2..., e.v3...) for e in model.elements)
+
+                gbm = GeometryBasics.mesh(model)
+                @test gbm isa GeometryBasics.Mesh{3, T, TriangleFace{Int}}
+                @test length(gbm.position) == length(model.nodes)
+                @test Set((p...,) for p in gbm.position) == nodes
+                @test length(gbm.faces) == length(model.elements)
+                @test Set(Tuple(c for p in gbm.position[[f...]] for c in p) for f in gbm.faces) == elems
+            end
+        end
+    end
+end


### PR DESCRIPTION
This can be used, e.g., for visualization through Makie:

```julia
GLMakie.mesh(GeometryBasics.mesh(model))
```