### PR TITLE
Backports 1.4.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental || false }}
     # Avoid running this job multiple times for pull requests based on local branches
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     timeout-minutes: 60
@@ -36,6 +37,9 @@ jobs:
         arch:
           - x64
           - x86
+        include:
+          - version: 'nightly'
+            experimental: true
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,8 +29,7 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - '1.10'
-          - 'pre'
+          - '1.11'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     # Avoid running this job multiple times for pull requests based on local branches
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,10 +35,10 @@ More examples are available in the `docs/examples/` directory.
 If you use `NESSie.jl` in your research, please cite the following publications:
 > Kemmer, T, Rjasanow, S., Hildebrandt, A (2018). NESSie. jl - Efficient and Intuitive
 > Finite Element and Boundary Element Methods for Nonlocal Protein Electrostatics in the
-> Julia Language. Journal of Computational Science 28, 193-203.
+> Julia Language. Journal of Computational Science 28, 193-203. DOI: [10.1016/j.jocs.2018.08.008](https://doi.org/10.1016/j.jocs.2018.08.008)
 
 > Kemmer, T (2021). Space-efficient and exact system representations for the nonlocal protein
-> electrostatics problem. Ph. D. thesis, Johannes Gutenberg University Mainz. Mainz, Germany.
+> electrostatics problem. Ph. D. thesis, Johannes Gutenberg University Mainz. Mainz, Germany. DOI: [10.25358/openscience-5689](https://doi.org/10.25358/openscience-5689)
 
 With BibTeX, you can use the following entries:
 ```
@@ -66,13 +66,13 @@ With BibTeX, you can use the following entries:
 
  * **[Åqv90]**
    J. Åqvist, Ion-water interaction potentials derived from free energy pertubation
-   simulations. J. Phys. Chem. 94: 8021, 1990.
+   simulations. J. Phys. Chem. 94: 8021, 1990. DOI: [10.1021/j100384a009](https://doi.org/10.1021/j100384a009)
 
  * **[Kea86]**
-   P. Keast, Moderate degree tetrahedral quadrature formulas. CMAME 55: 339-348, 1986.
+   P. Keast, Moderate degree tetrahedral quadrature formulas. CMAME 55: 339-348, 1986. DOI: [10.1016/0045-7825(86)90059-9](https://doi.org/10.1016/0045-7825(86)90059-9)
 
  * **[Rad48]**
-   J. Radon, Zur mechanischen Kubatur (in German). Monatsh. für Math. 52(4): 286-300, 1948.
+   J. Radon, Zur mechanischen Kubatur (in German). Monatsh. für Math. 52(4): 286-300, 1948. DOI: [10.1007/BF01525334](https://doi.org/10.1007/BF01525334)
 
  * **[Rja90]**
    S. Rjasanow, Vorkonditionierte iterative Auflösung von Randelementgleichungen für die
@@ -82,9 +82,9 @@ With BibTeX, you can use the following entries:
  * **[Ste03]**
    O. Steinbach, Numerische Näherungsverfahren für elliptische Randwertprobleme - Finite
    Elemente und Randelemente (in German). Advances in Numerical Matheamtics. Teubner
-   Verlag/GWV Fachverlage GmbH, Wiesbaden, 2003.
+   Verlag/GWV Fachverlage GmbH, Wiesbaden, 2003. DOI: [10.1007/978-3-322-80054-1](https://doi.org/10.1007/978-3-322-80054-1)
 
  * **[Xie16]**
    D. Xie, H. W. Volkmer, and J. Ying, Analytical solutions of nonlocal Poisson dielectric
    models with multiple point charges inside a dielectric sphere. Physical Review E 93(4):
-   043304, 2016.
+   043304, 2016. DOI: [10.1103/PhysRevE.93.043304](https://doi.org/10.1103/PhysRevE.93.043304)

--- a/docs/src/lib/constants.md
+++ b/docs/src/lib/constants.md
@@ -1,4 +1,7 @@
 # Constants
+```@meta
+    CurrentModule = NESSie
+```
 
 ## Global constants
 ```@docs

--- a/docs/src/lib/electrostatics.md
+++ b/docs/src/lib/electrostatics.md
@@ -1,4 +1,7 @@
 # Electrostatics
+```@meta
+    CurrentModule = NESSie
+```
 
 ## Potential types
 ```@docs
@@ -20,23 +23,23 @@
 ```@docs
     φmol
     ∂ₙφmol
-    NESSie.∇φmol
+    ∇φmol
 ```
 
 ### Interior potentials
 ```@docs
-    NESSie.BEM.φΩ
-    NESSie.TestModel.φΩ
+    BEM.φΩ
+    TestModel.φΩ
 ```
 
 
 ### Exterior potentials
 ```@docs
-    NESSie.BEM.φΣ
-    NESSie.TestModel.φΣ
+    BEM.φΣ
+    TestModel.φΣ
 ```
 
 ## Energies
 ```@docs
-    NESSie.BEM.rfenergy
+    BEM.rfenergy
 ```

--- a/docs/src/lib/models.md
+++ b/docs/src/lib/models.md
@@ -1,4 +1,7 @@
 # Models
+```@meta
+    CurrentModule = NESSie
+```
 
 ## Elements
 ```@docs

--- a/docs/src/lib/quadrature.md
+++ b/docs/src/lib/quadrature.md
@@ -1,4 +1,7 @@
 # Quadrature
+```@meta
+    CurrentModule = NESSie
+```
 
 ## Quadrature points
 ```@docs
@@ -20,12 +23,12 @@
 
 ## Laplace potential
 ```@docs
-    NESSie.Rjasanow.laplacecoll
-    NESSie.Rjasanow.laplacecoll!
+    Rjasanow.laplacecoll
+    Rjasanow.laplacecoll!
 ```
 
 ## Yukawa potential
 ```@docs
-    NESSie.Radon.regularyukawacoll
-    NESSie.Radon.regularyukawacoll!
+    Radon.regularyukawacoll
+    Radon.regularyukawacoll!
 ```

--- a/docs/src/lib/solvers.md
+++ b/docs/src/lib/solvers.md
@@ -1,4 +1,7 @@
 # Solvers
+```@meta
+    CurrentModule = NESSie
+```
 
 ## BEM solvers
 ```@meta

--- a/src/Radon.jl
+++ b/src/Radon.jl
@@ -254,7 +254,7 @@ to use the shorthand signature `regularyukawacoll` instead.
  * `yukawa` [Exponent](@ref int-constants) of the Yukawa operator's fundamental solution
 
 # Return type
-`Void`
+`T`
 """
 function radoncoll(
         ξ       ::AbstractVector{T},
@@ -368,7 +368,7 @@ triangle and observation point `ξ`.
  * `yukawa` [Exponent](@ref int-constants) of the Yukawa operator's fundamental solution
 
 # Return type
-`Void`
+`T`
 """
 @inline regularyukawacoll(
           ::Type{SingleLayer},

--- a/src/Radon.jl
+++ b/src/Radon.jl
@@ -163,7 +163,7 @@ to use the shorthand signature `regularyukawacoll!` instead.
  * `yukawa` [Exponent](@ref int-constants) of the Yukawa operator's fundamental solution
 
 # Return type
-`Void`
+`Nothing`
 """
 function radoncoll!(
         dest    ::AbstractVector{T},
@@ -306,7 +306,7 @@ vector.
  * `yukawa` [Exponent](@ref int-constants) of the Yukawa operator's fundamental solution
 
 # Return type
-`Void`
+`Nothing`
 """
 @inline regularyukawacoll!(
             ::Type{SingleLayer},

--- a/src/Rjasanow.jl
+++ b/src/Rjasanow.jl
@@ -282,7 +282,7 @@ vector.
     The result is premultiplied by 4π.
 
 # Return type
-`Void`
+`Nothing`
 """
 function laplacecoll!(
         ptype   ::Type{P},

--- a/src/Rjasanow.jl
+++ b/src/Rjasanow.jl
@@ -357,7 +357,7 @@ and observation point `ξ` [[Rja90]](@ref Bibliography).
     The result is premultiplied by 4π.
 
 # Return type
-`Void`
+`T`
 """
 function laplacecoll(
         ptype::Type{P},

--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -77,7 +77,7 @@ end
 
 # =========================================================================================
 """
-    struct Option{T <: AbstractFloat}
+    mutable struct Option{T <: AbstractFloat}
         εΩ::T       # dielectric constant of the solute
         εΣ::T       # dielectric constant of the solvent
         ε∞::T       # large-scale (bulk) solvent response

--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -103,10 +103,10 @@ end
     defaultopt(T::Type{Float64} = Float64)
     defaultopt(T::Type{Float32})
 
-Default system parameters
+Default system parameters for proteins in water.
 
 # Return type
-[`Option{T}`](@ref NESSie.Option)
+[`Option{T}`](@ref Option)
 
 # Default values
  * ``ε_Ω = 2``

--- a/src/base/potentials.jl
+++ b/src/base/potentials.jl
@@ -164,7 +164,7 @@ function ∇φmol(
         ξ      ::Vector{T},
         charges::Vector{Charge{T}}
     ) where T
-    isempty(charges) ? zero(T) :
+    isempty(charges) ? zeros(T, 3) :
         -sum(q.val * (ξ .- q.pos) / euclidean(ξ, q.pos)^3 for q in charges)
 end
 

--- a/src/base/quadrature.jl
+++ b/src/base/quadrature.jl
@@ -121,7 +121,7 @@ Quadrature points on a specific surface triangle, including weights.
 # Special constructors
 ```julia
 TriangleQuad(elem::Triangle{T})
-````
+```
 Computes quadrature points and weights for the given triangle.
 """
 struct TriangleQuad{T} <: ElementQuad{T}

--- a/src/base/quadrature.jl
+++ b/src/base/quadrature.jl
@@ -68,7 +68,7 @@ Generator function for quadrature points:
  * *Tetrahedra*: 5 points per element [[Kea86]](@ref Bibliography)
 
 # Return type
-`QuadPts2D` or `QuadPts3D`
+[`QuadPts2D`](@ref) or [`QuadPts3D`](@ref)
 """ quadraturepoints
 for T in [:Float64, :Float32]
     varname = Symbol("triquadpts_", T)

--- a/src/base/util.jl
+++ b/src/base/util.jl
@@ -241,7 +241,7 @@ is no such line, the stream handle will be set to EOF.
  * `skiptheline`    If true, said line will also be skipped
 
 # Return type
-`Void`
+`Nothing`
 """
 function _seek(fh::IOStream, prefix::String, skiptheline::Bool=true)
     m = -1

--- a/src/base/util.jl
+++ b/src/base/util.jl
@@ -11,7 +11,7 @@ and area. Returns the completely initialized Triangle as a copy.
     The given triangle remains unchanged!
 
 # Return type
-`Triangle`
+[`Triangle`](@ref)
 """
 function props(elem::Triangle{T}) where T
     # reject degenerate triangles
@@ -47,7 +47,7 @@ Merges two volume models, e.g., the models of a protein and the solvent. Duplica
 and charges (if any) are retained as well as the system constants of the first model.
 
 # Return type
-`Model{T, Tetrahedron{T}}`
+[`Model{T, Tetrahedron{T}}`](@ref)
 
 !!! note
     This function assumes that there are no duplicates within either of the node lists!

--- a/src/bem/implicit.jl
+++ b/src/bem/implicit.jl
@@ -99,7 +99,8 @@ Constructs and returns implicit representations for the single- and double-layer
 potential matrices `V` and `K` for the given observation points and surface elements.
 
 # Return type
-`Tuple{InteractionMatrix{T}, InteractionMatrix{T}}`
+[`Tuple{InteractionMatrix{T}, InteractionMatrix{T}}`]
+(https://tkemmer.github.io/ImplicitArrays.jl/stable/#ImplicitArrays.InteractionMatrix)
 """
 @inline function _get_laplace_matrices(
     Ξ       ::Vector{Vector{T}},
@@ -123,7 +124,8 @@ Constructs and returns implicit representations for the single- and double-layer
 potential matrices `V^Y` and `K^Y` for the given observation points and surface elements.
 
 # Return type
-`Tuple{InteractionMatrix{T}, InteractionMatrix{T}}`
+[`Tuple{InteractionMatrix{T}, InteractionMatrix{T}}`]
+(https://tkemmer.github.io/ImplicitArrays.jl/stable/#ImplicitArrays.InteractionMatrix)
 """
 @inline function _get_yukawa_matrices(
     Ξ::Vector{Vector{T}},

--- a/src/bem/local.jl
+++ b/src/bem/local.jl
@@ -33,7 +33,7 @@ end
 Computes the full local or nonlocal cauchy data on the surface of the given biomolecule.
 
 # Return type
-`LocalBEMResult{T, Triangle{T}}` or `NonlocalBEMResult{T, Triangle{T}}`
+[`LocalBEMResult{T, Triangle{T}}`](@ref) or [`NonlocalBEMResult{T, Triangle{T}}`](@ref)
 
 # Supported keyword arguments
  - `method::Symbol = :gmres`
@@ -70,7 +70,7 @@ Computes the full local or nonlocal cauchy data on the surface of the biomolecul
 *explicit* representation of the BEM system.
 
 # Return type
-`LocalBEMResult{T, Triangle{T}}` or `NonlocalBEMResult{T, Triangle{T}}`
+[`LocalBEMResult{T, Triangle{T}}`](@ref) or [`NonlocalBEMResult{T, Triangle{T}}`](@ref)
 """
 function _solve_explicit(
          ::Type{LocalES},
@@ -199,7 +199,7 @@ Computes the full local or nonlocal cauchy data on the surface of the biomolecul
 *implicit* representation of the BEM system.
 
 # Return type
-`LocalBEMResult{T, Triangle{T}}` or `NonlocalBEMResult{T, Triangle{T}}`
+[`LocalBEMResult{T, Triangle{T}}`](@ref) or [`NonlocalBEMResult{T, Triangle{T}}`](@ref)
 """
 function _solve_implicit(
          ::Type{LocalES},

--- a/src/bem/nonlocal.jl
+++ b/src/bem/nonlocal.jl
@@ -165,8 +165,14 @@ Implicit representation of the nonlocal BEM system matrix.
 
 # Special constructors
 ```julia
-
+function NonlocalSystemMatrix{T}(
+    Ξ       ::Vector{Vector{T}},
+    elements::Vector{Triangle{T}},
+    params  ::Option{T}
+) where T
 ```
+Creates the nonlocal system matrix directly from the given observation points `Ξ` and
+surface `elements`.
 """
 struct NonlocalSystemMatrix{T} <: AbstractArray{T, 2}
     """Single-layer Laplace potentials"""

--- a/src/format/hmo.jl
+++ b/src/format/hmo.jl
@@ -8,7 +8,7 @@
 Reads a complete surface model from the given HMO file.
 
 # Return type
-`Model{T, Triangle{T}}`
+[`Model{T, Triangle{T}}`](@ref)
 
 # Alias
 
@@ -69,7 +69,7 @@ end
 Reads all elements from the given HMO file.
 
 # Return type
-`Vector{Triangle{T}}`
+[`Vector{Triangle{T}}`](@ref Triangle)
 """
 function readhmo_elements(
         stream::IOStream,
@@ -96,7 +96,7 @@ end
 Reads all charges from the given HMO file.
 
 # Return type
-`Vector{Charge{T}}`
+[`Vector{Charge{T}}`](@ref Charge)
 """
 function readhmo_charges(
         stream::IOStream,

--- a/src/format/hmo.jl
+++ b/src/format/hmo.jl
@@ -123,7 +123,7 @@ end
 Creates a HMO file from the given surface model.
 
 # Return type
-`Void`
+`Nothing`
 
 # Alias
 

--- a/src/format/mcsf.jl
+++ b/src/format/mcsf.jl
@@ -17,7 +17,7 @@ Reads a volume model from the given GAMer-generated mcsf file.
  * `domain` Element domain (solute `:Ω`, solvent `:Σ`, or `:none`)
 
 # Return type
-`Model{T, Tetrahedron{T}}`
+[`Model{T, Tetrahedron{T}}`](@ref)
 
 # Aliases
 
@@ -104,7 +104,7 @@ end
 Reads all elements from the given GAMer-generated mcsf file.
 
 # Return type
-`Vector{Tetrahedron{T}}`
+[`Vector{Tetrahedron{T}}`](@ref Tetrahedron)
 """
 function readmcsf_elements(
         stream::IOStream,

--- a/src/format/msms.jl
+++ b/src/format/msms.jl
@@ -13,7 +13,7 @@ Reads a surface model from the given MSMS-generated `.face` and `.vert` files.
     `Model` object is empty and has to be set separately.
 
 # Return type
-`Model{T, Triangle{T}}`
+[`Model{T, Triangle{T}}`](@ref)
 
 # Alias
 
@@ -76,7 +76,7 @@ end
 Reads all elements from the given MSMS-generated `.face` file.
 
 # Return type
-`Vector{Triangle{T}}`
+[`Vector{Triangle{T}}`](@ref Triangle)
 """
 function readmsms_elements(
         stream::IOStream,

--- a/src/format/obj.jl
+++ b/src/format/obj.jl
@@ -12,7 +12,7 @@ Creates a Wavefront OBJ file from a given surface model.
     <http://paulbourke.net/dataformats/obj/>
 
 # Return type
-`Void`
+`Nothing`
 
 # Alias
 

--- a/src/format/off.jl
+++ b/src/format/off.jl
@@ -15,7 +15,7 @@ Reads a surface model from the given OFF file.
 <http://www.geomview.org/docs/html/OFF.html>
 
 # Return type
-`Model{T}`
+[`Model{T}`](@ref)
 
 # Alias
 
@@ -79,7 +79,7 @@ end
 Reads the first `n` elements from the given OFF file.
 
 # Return type
-`Vector{Triangle{T}}`
+[`Vector{Triangle{T}}`](@ref Triangle)
 """
 function readoff_elements(
         stream::IOStream,

--- a/src/format/pqr.jl
+++ b/src/format/pqr.jl
@@ -11,7 +11,7 @@ Reads a charge model from the given PQR file.
 <https://pdb2pqr.readthedocs.io/en/latest/formats/pqr.html>
 
 # Return type
-`Vector{Charge{T}}`
+[`Vector{Charge{T}}`](@ref Charge)
 
 # Alias
 

--- a/src/format/skel.jl
+++ b/src/format/skel.jl
@@ -12,7 +12,7 @@ collection of points and polylines.
 <http://www.geomview.org/docs/html/SKEL.html>
 
 # Return type
-`Void`
+`Nothing`
 
 # Alias
 

--- a/src/format/stl.jl
+++ b/src/format/stl.jl
@@ -78,7 +78,7 @@ Creates a binary STL file from a given surface model.
 <http://www.fabbers.com/tech/STL_Format>
 
 # Return type
-`Void`
+`Nothing`
 
 # Alias
 

--- a/src/format/vtk.jl
+++ b/src/format/vtk.jl
@@ -17,7 +17,7 @@ type is determined by the given model:
 <https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf>
 
 # Return type
-`Void`
+`Nothing`
 
 # Alias
 

--- a/src/format/xml3d.jl
+++ b/src/format/xml3d.jl
@@ -12,7 +12,7 @@ latter as point cloud) or from a given surface model.
 <https://github.com/xml3d/xml3d.js/wiki/External-resources>
 
 # Return type
-`Void`
+`Nothing`
 
 # Alias
 
@@ -94,7 +94,7 @@ as point cloud.
 <https://github.com/xml3d/xml3d.js/wiki/External-resources>
 
 # Return type
-`Void`
+`Nothing`
 
 # Alias
 

--- a/src/testmodel/born/model.jl
+++ b/src/testmodel/born/model.jl
@@ -43,7 +43,7 @@ Generator function for built-in Born ions:
 | Ba   | +2     | 1.385                               |
 
 ## Return type
-`BornIon`
+[`BornIon{T}`](@ref)
 """ bornion
 for T in [:Float64, :Float32]
     varname = Symbol("bornions_", T)

--- a/src/testmodel/xie/model.jl
+++ b/src/testmodel/xie/model.jl
@@ -68,7 +68,7 @@ located at 80% `radius` distance from the origin.
    the results to the reference.
 
 # Return type
-`Vector{Charge{T}}`
+[`Vector{Charge{T}}`](@ref Charge)
 """
 function scalemodel(
         charges::Vector{Charge{T}},

--- a/src/testmodel/xie/model.jl
+++ b/src/testmodel/xie/model.jl
@@ -58,9 +58,9 @@ end
     )
 
 Translates and rescales the given point charge model to fit inside an origin-centered
-sphere with the specified radius. More specifically, the function will center the given
-model at the origin and scaled in a way such that the outermost point charge will be
-located at 80% `radius` distance from the origin.
+sphere with the specified radius. More specifically, the model is centered at the origin and,
+if it contains more than one charge, scaled in a way such that the outermost point charge will
+be located at 80% `radius` distance from the origin.
 
 # Arguments
  * `compat` Enables compatibility mode and scales the model exactly like the reference
@@ -81,8 +81,8 @@ function scalemodel(
 
     # compute and apply scaling factor
     h = x -> compat ? ceil(x) : x  # in compat mode, scaling factor is rounded up
-    sf = .8radius / h(maximum(_norm(pos) for pos in newpos))
-    rmul!(newpos, sf)
+    sf = h(maximum(_norm(pos) for pos in newpos))
+    sf > 0 && rmul!(newpos, .8radius / sf)
 
     [Charge{T}(pos, q.val) for (pos, q) in zip(newpos, charges)]
 end

--- a/src/testmodel/xie/nonlocal1.jl
+++ b/src/testmodel/xie/nonlocal1.jl
@@ -115,7 +115,7 @@ function coefficients(model::XieModel{T}, len::Int) where T
 
     @inbounds for (qi, q) in enumerate(model.charges)
         r  = _norm(q.pos)
-        iᵣ = spherical_besseli(len, r/λ)
+        iᵣ = spherical_besseli(len, max(1e-10, r/λ))
         for n in 0:len-1
             dₙ = d[n+1]
             wₙ = w[n+1]

--- a/src/testmodel/xie/potentials.jl
+++ b/src/testmodel/xie/potentials.jl
@@ -56,7 +56,7 @@ function φΩ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
         φ += φj * q.val
     end
 
-    (φ + φmol(ξ, model.charges) / 4π / εΩ) * T(ec/ε0)
+    (φ + φmol(ξ, model.charges) / T(4π) / εΩ) * T(ec/ε0)
 end
 
 

--- a/src/testmodel/xie/potentials.jl
+++ b/src/testmodel/xie/potentials.jl
@@ -31,7 +31,7 @@ function φΩ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
 
         # if ξ is close to the origin, all terms for n > 0 become negligible
         if r < 1e-10
-            φ += A₃[1, qi]
+            φ += A₃[1, qi] * q.val
             continue
         end
 

--- a/test/testmodel/xie.jl
+++ b/test/testmodel/xie.jl
@@ -36,6 +36,16 @@
                 Charge(T[0, 1, 0, 4]...)
             ]
 
+            # single charge only
+            scaled = scalemodel([first(charges)], T(√(.5)/.8))
+            @test typeof(scaled) == Vector{Charge{T}}
+            @test scaled[1].pos ≈ T[0, 0, 0]
+            @test scaled[1].val == one(T)
+            scaled = scalemodel([Charge(T[1, 1, 1, 2]...)], T(√(.5)/.8))
+            @test typeof(scaled) == Vector{Charge{T}}
+            @test scaled[1].pos ≈ T[0, 0, 0]
+            @test scaled[1].val == 2one(T)
+
             # translation only
             scaled = scalemodel(charges, T(√(.5)/.8))
             @test typeof(scaled) == Vector{Charge{T}}


### PR DESCRIPTION
 - [x] [Docs: fix docstrings](https://github.com/tkemmer/NESSie.jl/commit/d3063653261a7bb56c6b4b51156415ba4fa9519b)
 - [x] [Docs: add missing type refs to docstrings](https://github.com/tkemmer/NESSie.jl/commit/9069ea7c63bb66e8e578fb1f92aeedd5784eebca)
 - [x] [Docs: fix {Void => Nothing} in docstrings](https://github.com/tkemmer/NESSie.jl/commit/5b5dc46d0440681034c2efe68dec5be778616b61)
 - [x] [Docs: add module context to all doc files](https://github.com/tkemmer/NESSie.jl/commit/03f5ad74e73dba5ce429ddd1f20ec445405e9439)
 - [x] [Base: fix docstring of Option](https://github.com/tkemmer/NESSie.jl/commit/b41b66276e0fd5673ceebf855f6ca30a00ff0f9a)
 - [x] [Base: fix ∇φmol w/ empty charge lists](https://github.com/tkemmer/NESSie.jl/commit/307d82b708bd4baf0ea616097e30389a5422fa8d)
 - [x] [TestModel: fix scalemodel w/ single-charge models](https://github.com/tkemmer/NESSie.jl/commit/2651f756f138d00d4474a5c0ad65ccc979b02265)
 - [x] [TestModel: fix interior potential for NonlocalXieModel1 w/ ξ=0](https://github.com/tkemmer/NESSie.jl/commit/e70140a41054869064ae5518adff519716974afd)
 - [x] [TestModel: fix NonlocalXieModel1 coefficients w/ charges in the origin](https://github.com/tkemmer/NESSie.jl/commit/8a750d43834afcf8496e1ab1d7d56c79bc5c0af3)
 - [x] [TestModel: fix NonlocalXieModel potentials w/ charges in the origin](https://github.com/tkemmer/NESSie.jl/commit/ce4def9b5b02d215baf1ae8cc802ffe0e11abf3f)
 - [x] [TestModel: fix type instability in φΩ(ξ, ::NonlocalXieModel1)](https://github.com/tkemmer/NESSie.jl/commit/51c07ee38ee53cf976dfe7ceed468c3b9edc1efa)
 - [x] [Docs: add DOIs where available](https://github.com/tkemmer/NESSie.jl/commit/7d5166e07e9b400d890e13fdae290af51156a77b)
 - [x] [CI: adapt to 1.11 release and LTS bump](https://github.com/tkemmer/NESSie.jl/commit/356f08632e118b63a0ecd2d790018964ed218e03)
 - [x] [CI: merge updates from PkgTemplates.jl](https://github.com/tkemmer/NESSie.jl/commit/36f3f7da26fa25343f9b78e8c485ac4bbfa5cd76)
 - [x] [CI: make build failures on Julia nightly non-critical](https://github.com/tkemmer/NESSie.jl/commit/f713bad9bb4cef2d352f4a698ace8ec035f2564e)
 - [x] [CI: set coverage=false for testing](https://github.com/tkemmer/NESSie.jl/commit/8015edf350c68106e02acc394d3a76f886f7c6ab)