### PR TITLE
Base: move potential functions to main module to avoid clashes

### DIFF
--- a/docs/src/lib/electrostatics.md
+++ b/docs/src/lib/electrostatics.md
@@ -32,18 +32,16 @@ Pages = ["electrostatics.md"]
 
 ### Interior potentials
 ```@docs
-    BEM.φΩ
-    TestModel.φΩ
+    φΩ
 ```
 
 
 ### Exterior potentials
 ```@docs
-    BEM.φΣ
-    TestModel.φΣ
+    φΣ
 ```
 
-## Energies
+### Reaction field potentials
 ```@docs
-    BEM.rfenergy
+    rfenergy
 ```

--- a/src/BEM.jl
+++ b/src/BEM.jl
@@ -10,7 +10,7 @@ using IterativeSolvers: gmres
 using LinearAlgebra
 using Preconditioners: DiagonalPreconditioner
 
-export BEMResult, LocalBEMResult, NonlocalBEMResult, rfenergy, solve, φΩ, φΣ
+export BEMResult, LocalBEMResult, NonlocalBEMResult, solve
 
 """
     abstract type BEMResult{T, E <: SurfaceElement{T}} end

--- a/src/NESSie.jl
+++ b/src/NESSie.jl
@@ -20,7 +20,7 @@ export meshunion, obspoints_line, obspoints_plane
 
 include("base/potentials.jl")
 export PotentialType, SingleLayer, DoubleLayer, LocalityType, LocalES, NonlocalES, φmol,
-    ∂ₙφmol, ∇φmol
+    ∂ₙφmol, ∇φmol, φΩ, φΣ
 
 # Submodules
 include("Format.jl")

--- a/src/TestModel.jl
+++ b/src/TestModel.jl
@@ -14,7 +14,6 @@ include("testmodel/born/model.jl")
 export BornIon, bornion
 
 include("testmodel/born/potentials.jl")
-export φΩ, φΣ
 
 #=
     Multi-charge spheres

--- a/src/base/potentials.jl
+++ b/src/base/potentials.jl
@@ -174,3 +174,8 @@ end
     ) where T
     [∇φmol(ξ, charges) for ξ in Ξ]
 end
+
+# Function stubs for potentials in submodules
+function φΣ end
+function φΩ end
+function rfenergy end

--- a/src/bem/post.jl
+++ b/src/bem/post.jl
@@ -14,7 +14,7 @@ where ``φ^*`` is the reaction field and ``ρ`` is the corresponding charge dist
 # Return type
 `T`
 """
-function rfenergy(bem::R) where {T, R <: BEMResult{T}}
+function NESSie.rfenergy(bem::R) where {T, R <: BEMResult{T}}
     qposs = [charge.pos for charge in bem.model.charges]
     qvals = [charge.val for charge in bem.model.charges]
 
@@ -62,7 +62,7 @@ of observation points `Ξ`.
 # Return type
 `Vector{T}`
 """
-function φΩ(
+function NESSie.φΩ(
         Ξ         ::Vector{Vector{T}},
         bem       ::R
     ) where {T, R <: BEMResult{T}}
@@ -113,7 +113,7 @@ of observation points `Ξ`.
 # Return type
 `Vector{T}`
 """
-function φΣ(
+function NESSie.φΣ(
         Ξ         ::Vector{Vector{T}},
         bem       ::LocalBEMResult{T}
     ) where T
@@ -142,7 +142,7 @@ function φΣ(
     φ
 end
 
-function φΣ(
+function NESSie.φΣ(
         Ξ         ::Vector{Vector{T}},
         bem       ::NonlocalBEMResult{T}
     ) where T

--- a/src/testmodel/born/potentials.jl
+++ b/src/testmodel/born/potentials.jl
@@ -19,7 +19,7 @@ observation point ``ξ``.
 !!! warning
     This function does not verify whether ξ is located inside of the sphere!
 """
-function φΩ(
+function NESSie.φΩ(
         ::Type{LocalES},
         ξ::Vector{T},
         ion::BornIon{T},
@@ -29,7 +29,7 @@ function φΩ(
         (1/euclidean(ion.charge.pos, ξ) + 1/ion.radius * (1/opt.εΣ - 1))
 end
 
-function φΩ(
+function NESSie.φΩ(
         ::Type{NonlocalES},
         ξ::Vector{T},
         ion::BornIon{T},
@@ -63,7 +63,7 @@ observation point ``ξ``.
 !!! warning
     This function does not verify whether ξ is located outside of the sphere!
 """
-function φΣ(
+function NESSie.φΣ(
         ::Type{LocalES},
         ξ::Vector{T},
         ion::BornIon{T},
@@ -72,7 +72,7 @@ function φΣ(
     potprefactor(T) * ion.charge.val / opt.εΣ / euclidean(ion.charge.pos, ξ)
 end
 
-function φΣ(
+function NESSie.φΣ(
         ::Type{NonlocalES},
         ξ::Vector{T},
         ion::BornIon{T},

--- a/src/testmodel/xie/potentials.jl
+++ b/src/testmodel/xie/potentials.jl
@@ -17,7 +17,7 @@ point ``ξ``.
 !!! warning
     This function does not verify whether ξ is located inside of the sphere!
 """
-function φΩ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
+function NESSie.φΩ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
     a  = model.radius
     λ  = model.params.λ
     εΩ = model.params.εΩ
@@ -75,7 +75,7 @@ point ``ξ``.
 !!! warning
     This function does not verify whether ξ is located outside of the sphere!
 """
-function φΣ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
+function NESSie.φΣ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
     a  = model.radius
     λ  = model.params.λ
     εΣ = model.params.εΣ


### PR DESCRIPTION
This avoids warnings and issues, e.g., when using both `BEM` and `TestModel` submodules.