### PR TITLE
TestModel: include system constants in BornIon, update potentials to use them

### DIFF
--- a/src/TestModel.jl
+++ b/src/TestModel.jl
@@ -28,4 +28,7 @@ export NonlocalXieModel1
 
 include("testmodel/xie/potentials.jl")
 
+# deprecations
+include("testmodel/deprecation.jl")
+
 end # module

--- a/src/testmodel/born/potentials.jl
+++ b/src/testmodel/born/potentials.jl
@@ -1,10 +1,6 @@
 # =========================================================================================
 """
-    φΩ(
-           ::Type{<: LocalityType},
-        ξ  ::Vector{T},
-        ion::BornIon{T}
-    )
+    φΩ(::Type{<: LocalityType}, ξ::Vector{T}, ion::BornIon{T})
 
 Computes the interior local or nonlocal electrostatic potential ``φ_Ω`` for the given
 observation point ``ξ``.
@@ -14,6 +10,11 @@ observation point ``ξ``.
 
 ## Return type
 `T`
+
+## Alias
+    φΩ(::Type{<: LocalityType}, Ξ::Vector{Vector{T}}, ion::BornIon{T})
+
+Computes the potentials for all observation points ``ξ \\in Ξ``.
 
 !!! warning
     This function does not verify whether ξ is located inside of the sphere!
@@ -39,14 +40,17 @@ function NESSie.φΩ(
         (1 - opt.εΣ + (opt.εΣ - opt.ε∞)/opt.ε∞ * sinh(ν)/ν * exp(-ν)))
 end
 
+@inline function NESSie.φΩ(
+    lt::Type{<: LocalityType},
+    Ξ,
+    ion::BornIon{T}
+) where T
+    φΩ.(lt, Ξ, Ref(ion))
+end
 
 # =========================================================================================
 """
-    φΣ(
-           ::Type{<: LocalityType},
-        ξ  ::Vector{T},
-        ion::BornIon{T}
-    )
+    φΣ(::Type{<: LocalityType}, ξ::Vector{T}, ion::BornIon{T})
 
 Computes the exterior local or nonlocal electrostatic potential ``φ_Σ`` for the given
 observation point ``ξ``.
@@ -56,6 +60,11 @@ observation point ``ξ``.
 
 ## Return type
 `T`
+
+## Alias
+    φΣ(::Type{<: LocalityType}, Ξ::Vector{Vector{T}}, ion::BornIon{T})
+
+Computes the potentials for all observation points ``ξ \\in Ξ``.
 
 !!! warning
     This function does not verify whether ξ is located outside of the sphere!
@@ -78,4 +87,12 @@ function NESSie.φΣ(
     ν = sqrt(opt.εΣ/opt.ε∞) * ion.radius / opt.λ
     potprefactor(T) * ion.charge.val / opt.εΣ /
         r * (1 + (opt.εΣ - opt.ε∞)/opt.ε∞ * sinh(ν)/ν * exp(-ν * r/ion.radius))
+end
+
+@inline function NESSie.φΣ(
+    lt::Type{<: LocalityType},
+    Ξ,
+    ion::BornIon{T}
+) where T
+    φΣ.(lt, Ξ, Ref(ion))
 end

--- a/src/testmodel/born/potentials.jl
+++ b/src/testmodel/born/potentials.jl
@@ -3,8 +3,7 @@
     φΩ(
            ::Type{<: LocalityType},
         ξ  ::Vector{T},
-        ion::BornIon{T},
-        opt::Option{T} = defaultopt(T)
+        ion::BornIon{T}
     )
 
 Computes the interior local or nonlocal electrostatic potential ``φ_Ω`` for the given
@@ -22,19 +21,18 @@ observation point ``ξ``.
 function NESSie.φΩ(
         ::Type{LocalES},
         ξ::Vector{T},
-        ion::BornIon{T},
-        opt::Option{T}=defaultopt(T)
+        ion::BornIon{T}
     ) where T
     potprefactor(T) * ion.charge.val *
-        (1/euclidean(ion.charge.pos, ξ) + 1/ion.radius * (1/opt.εΣ - 1))
+        (1/euclidean(ion.charge.pos, ξ) + 1/ion.radius * (1/ion.params.εΣ - 1))
 end
 
 function NESSie.φΩ(
         ::Type{NonlocalES},
         ξ::Vector{T},
-        ion::BornIon{T},
-        opt::Option{T}=defaultopt(T)
+        ion::BornIon{T}
     ) where T
+    opt = ion.params
     r = euclidean(ion.charge.pos, ξ)
     ν = sqrt(opt.εΣ/opt.ε∞) * ion.radius / opt.λ
     potprefactor(T) * ion.charge.val * (1/r + 1/ion.radius/opt.εΣ *
@@ -47,8 +45,7 @@ end
     φΣ(
            ::Type{<: LocalityType},
         ξ  ::Vector{T},
-        ion::BornIon{T},
-        opt::Option{T} = defaultopt(T)
+        ion::BornIon{T}
     )
 
 Computes the exterior local or nonlocal electrostatic potential ``φ_Σ`` for the given
@@ -66,18 +63,17 @@ observation point ``ξ``.
 function NESSie.φΣ(
         ::Type{LocalES},
         ξ::Vector{T},
-        ion::BornIon{T},
-        opt::Option{T}=defaultopt(T)
+        ion::BornIon{T}
     ) where T
-    potprefactor(T) * ion.charge.val / opt.εΣ / euclidean(ion.charge.pos, ξ)
+    potprefactor(T) * ion.charge.val / ion.params.εΣ / euclidean(ion.charge.pos, ξ)
 end
 
 function NESSie.φΣ(
         ::Type{NonlocalES},
         ξ::Vector{T},
-        ion::BornIon{T},
-        opt::Option{T}=defaultopt(T)
+        ion::BornIon{T}
     ) where T
+    opt = ion.params
     r = euclidean(ion.charge.pos, ξ)
     ν = sqrt(opt.εΣ/opt.ε∞) * ion.radius / opt.λ
     potprefactor(T) * ion.charge.val / opt.εΣ /

--- a/src/testmodel/deprecation.jl
+++ b/src/testmodel/deprecation.jl
@@ -1,0 +1,33 @@
+# `opt` argument removed in v1.5
+function NESSie.φΩ(
+    lt::Type{<: LocalityType},
+    ξ::Vector{T},
+    ion::BornIon{T},
+    opt::Option{T}
+) where T
+    Base.depwarn(
+        "The `opt` parameter is deprecated and will be removed in a future" *
+        "release! Instead, please set `ion.params` accordingly.",
+        :φΩ
+    )
+    ion_copy = deepcopy(ion)
+    ion_copy.params = opt
+    φΩ(lt, ξ, ion_copy)
+end
+
+# `opt` argument removed in v1.5
+function NESSie.φΣ(
+    lt::Type{<: LocalityType},
+    ξ::Vector{T},
+    ion::BornIon{T},
+    opt::Option{T}
+) where T
+    Base.depwarn(
+        "The `opt` parameter is deprecated and will be removed in a future" *
+        "release! Instead, please set `ion.params` accordingly.",
+        :φΣ
+    )
+    ion_copy = deepcopy(ion)
+    ion_copy.params = opt
+    φΣ(lt, ξ, ion_copy)
+end

--- a/src/testmodel/xie/potentials.jl
+++ b/src/testmodel/xie/potentials.jl
@@ -14,6 +14,11 @@ point ``ξ``.
 # Return type
 `T`
 
+## Alias
+    φΩ(Ξ::Vector{Vector{T}}, model::NonlocalXieModel1{T})
+
+Computes the potentials for all observation points ``ξ \\in Ξ``.
+
 !!! warning
     This function does not verify whether ξ is located inside of the sphere!
 """
@@ -55,6 +60,10 @@ function NESSie.φΩ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
     (φ + φmol(ξ, model.charges) / 4π / εΩ) * T(ec/ε0)
 end
 
+@inline function NESSie.φΩ(Ξ, model::NonlocalXieModel1)
+    φΩ.(Ξ, Ref(model))
+end
+
 
 # =========================================================================================
 """
@@ -71,6 +80,11 @@ point ``ξ``.
 
 # Return type
 `T`
+
+## Alias
+    φΣ(Ξ::Vector{Vector{T}}, model::NonlocalXieModel1{T})
+
+Computes the potentials for all observation points ``ξ \\in Ξ``.
 
 !!! warning
     This function does not verify whether ξ is located outside of the sphere!
@@ -109,4 +123,8 @@ function NESSie.φΣ(ξ::Vector{T}, model::NonlocalXieModel1{T}) where T
     end
 
     φ * T(ec/ε0)
+end
+
+@inline function NESSie.φΣ(Ξ, model::NonlocalXieModel1)
+    φΣ.(Ξ, Ref(model))
 end

--- a/test/testmodel/born.jl
+++ b/test/testmodel/born.jl
@@ -3,6 +3,12 @@
 
     using NESSie.TestModel
 
+    @testset "defaultopt" begin
+        for T in testtypes
+            @test typeof(defaultopt(BornIon{T})) == Option{T}
+        end
+    end
+
     @testset "bornion" begin
         for T in testtypes
             @test typeof(bornion("Na", T)) == BornIon{T}


### PR DESCRIPTION
This PR also introduces `defaultopt(BornIon{T})`, providing a different set of default system contants for vacuum-filled systems in water (as compared to proteins in water, which we usually assume).