### PR TITLE
Base: fix `∇φmol` w/ empty charge lists

### DIFF
--- a/src/base/potentials.jl
+++ b/src/base/potentials.jl
@@ -164,7 +164,7 @@ function ∇φmol(
         ξ      ::Vector{T},
         charges::Vector{Charge{T}}
     ) where T
-    isempty(charges) ? zero(T) :
+    isempty(charges) ? zeros(T, 3) :
         -sum(q.val * (ξ .- q.pos) / euclidean(ξ, q.pos)^3 for q in charges)
 end
 


### PR DESCRIPTION
Fixes: #16