### PR TITLE
Backports v1.4.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
         version:
           - 'lts'
           - '1.11'
-          - '1.12-nightly'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
           - x64
           - x86
         include:
-          - version: '1.12-nightly'
+          - version: 'pre'
             experimental: true
           - version: 'nightly'
             experimental: true


### PR DESCRIPTION
- [x] [CI: use Julia pre instead of 1.12-nightly](https://github.com/tkemmer/NESSie.jl/commit/d964f757b6c934c5d4411cd7a5c8e55e58c71b49)