### PR TITLE
Rjasanow/Radon: add multi-threading support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.4.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -23,6 +24,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Aqua = "0.8.9"
 AutoHashEquals = "2.2.0"
+ChunkSplitters = "3.1.1"
 Distances = "0.7.2, 0.8, 0.9, 0.10"
 FileIO = "1.16.6"
 GeometryBasics = "0.5.5"

--- a/docs/src/intern/radon.md
+++ b/docs/src/intern/radon.md
@@ -9,8 +9,5 @@ Pages = ["radon.md"]
 
 
 ```@docs
-    radoncoll
-    radoncoll!
-    regularyukawapot
-    ∂ₙregularyukawapot
+    _regularyukawapot
 ```

--- a/docs/src/intern/rjasanow.md
+++ b/docs/src/intern/rjasanow.md
@@ -11,7 +11,7 @@ Pages = ["rjasanow.md"]
     ObservationPosition
     InPlane
     InSpace
-    laplacepot
+    _laplacepot
     _logterm
     _projectξ!
 ```

--- a/src/Rjasanow.jl
+++ b/src/Rjasanow.jl
@@ -2,6 +2,8 @@ module Rjasanow
 
 using ..NESSie
 using ..NESSie: _cos, _etol, _norm, _sign, cathetus, distance
+using ChunkSplitters
+using LinearAlgebra
 
 export laplacecoll, laplacecoll!
 
@@ -24,7 +26,7 @@ struct InSpace <: ObservationPosition end
 
 # =========================================================================================
 """
-    function laplacepot(
+    function _laplacepot(
         ptype::Type{<: PotentialType},
         ξ    ::AbstractVector{T},
         elem ::Triangle{T},
@@ -47,22 +49,22 @@ observation point `ξ`. The latter needs to be projected onto the surface elemen
 # Return type
 `T`
 """
-@inline function laplacepot(
-        ptype::Type{P},
-        ξ    ::AbstractVector{T},
-        elem ::Triangle{T},
-        dist ::T;
-        dat  ::AbstractVector{T} = Vector{T}(undef, 9)
-    ) where {T, P <: PotentialType}
-    laplacepot(ptype, ξ, elem.v1, elem.v2, elem.normal, dist; dat=dat) +
-    laplacepot(ptype, ξ, elem.v2, elem.v3, elem.normal, dist; dat=dat) +
-    laplacepot(ptype, ξ, elem.v3, elem.v1, elem.normal, dist; dat=dat)
+@inline function _laplacepot(
+    ptype::Type{<: PotentialType},
+    ξ::AbstractVector{T},
+    elem::Triangle{T},
+    dist::T;
+    dat::AbstractVector{T} = Vector{T}(undef, 9)
+) where T
+    _laplacepot(ptype, ξ, elem.v1, elem.v2, elem.normal, dist; dat) +
+    _laplacepot(ptype, ξ, elem.v2, elem.v3, elem.normal, dist; dat) +
+    _laplacepot(ptype, ξ, elem.v3, elem.v1, elem.normal, dist; dat)
 end
 
 
 # =========================================================================================
 """
-    laplacepot(
+    _laplacepot(
         ptype ::Type{<: PotentialType},
         ξ     ::AbstractVector{T},
         x1    ::AbstractVector{T},
@@ -89,15 +91,15 @@ onto the surface element plane  [[Rja90]](@ref Bibliography).
 # Return type
 `T`
 """
-function laplacepot(
-        ptype ::Type{P},
-        ξ     ::AbstractVector{T},
-        x1    ::AbstractVector{T},
-        x2    ::AbstractVector{T},
-        normal::AbstractVector{T},
-        dist  ::T;
-        dat   ::AbstractVector{T} = Vector{T}(undef, 9)
-    ) where {T, P <: PotentialType}
+function _laplacepot(
+    ptype::Type{<: PotentialType},
+    ξ::AbstractVector{T},
+    x1::AbstractVector{T},
+    x2::AbstractVector{T},
+    normal::AbstractVector{T},
+    dist::T;
+    dat::AbstractVector{T} = Vector{T}(undef, 9)
+) where T
     u1 = view(dat, 1:3)
     u2 = view(dat, 4:6)
     v  = view(dat, 7:9)
@@ -140,16 +142,14 @@ function laplacepot(
     # side of v the observation point lies. This is equivalent to checking whether the
     # normal of the triangle here and the one of the surface element (which are obviously
     # (anti)parallel) are oriented alike.
-    pot = abs(dist) < _etol(T) ?
-        laplacepot(ptype, InPlane, sinφ1, sinφ2, h, dist) :
-        laplacepot(ptype, InSpace, sinφ1, sinφ2, h, dist)
-    _sign(u1, u2, normal) * pot
+    _sign(u1, u2, normal) *
+        _laplacepot(ptype, abs(dist) < _etol(T) ? InPlane : InSpace, sinφ1, sinφ2, h, dist)
 end
 
 
 # =========================================================================================
 """
-    laplacepot(
+    _laplacepot(
              ::Type{<: PotentialType},
              ::Type{<: ObservationPosition},
         sinφ1::T,
@@ -172,32 +172,31 @@ sines of the angles ``φ₁`` and ``φ₂`` between `h` and the triangle sides e
 # Return type
 `T`
 """
-@inline function laplacepot(
-             ::Type{SingleLayer},
-             ::Type{InPlane},
-        sinφ1::T,
-        sinφ2::T,
-        h    ::T,
-        d    ::T
-    ) where T
+@inline function _laplacepot(
+    ::Type{SingleLayer},
+    ::Type{InPlane},
+    sinφ1::T,
+    sinφ2::T,
+    h::T,
+    d::T
+) where T
     #=
         h/8π * [ln((1 + sin(φ))/(1 - sin(φ)))]   from φ1 to φ2
         = h/8π * [ln((1 + sin(φ2))/(1 - sin(φ2))) - ln((1 + sin(φ1))/(1 - sin(φ1)))]
         = h/8π * ln((1 + sin(φ2))(1 - sin(φ1))/((1 - sin(φ2))(1 + sin(φ1))))
-
         The equation in the original source misses a factor of 0.5!
     =#
     h * log((1+sinφ2) * (1-sinφ1) / ((1-sinφ2) * (1+sinφ1))) / 2
 end
 
-@inline function laplacepot(
-             ::Type{SingleLayer},
-             ::Type{InSpace},
-        sinφ1::T,
-        sinφ2::T,
-        h    ::T,
-        d    ::T
-    ) where T
+@inline function _laplacepot(
+    ::Type{SingleLayer},
+    ::Type{InSpace},
+    sinφ1::T,
+    sinφ2::T,
+    h::T,
+    d::T
+) where T
     #=
         h/8π * <1> + d/4π * <2>
 
@@ -225,14 +224,14 @@ end
     result + d * (asin(χ * sinφ2) - asin(sinφ2) - asin(χ * sinφ1) + asin(sinφ1))
 end
 
-@inline function laplacepot(
-             ::Type{DoubleLayer},
-             ::Type{InPlane},
-        sinφ1::T,
-        sinφ2::T,
-        h    ::T,
-        d    ::T
-    ) where T
+@inline function _laplacepot(
+    ::Type{DoubleLayer},
+    ::Type{InPlane},
+    sinφ1::T,
+    sinφ2::T,
+    h::T,
+    d::T
+) where T
     #=
         1/4π * ∫-1/|ξ-r'|^3 * (ξ-r')⋅n dr'
         = 1/4π * ∫-1/|ξ-r'|^3 * 0 dr'
@@ -241,14 +240,14 @@ end
     zero(T)
 end
 
-@inline function laplacepot(
-             ::Type{DoubleLayer},
-             ::Type{InSpace},
-        sinφ1::T,
-        sinφ2::T,
-        h    ::T,
-        d    ::T
-    ) where T
+@inline function _laplacepot(
+    ::Type{DoubleLayer},
+    ::Type{InSpace},
+    sinφ1::T,
+    sinφ2::T,
+    h::T,
+    d::T
+) where T
     χ  = abs(d) / √(d^2 + h^2)
     sign(d) * (asin(χ * sinφ1) - asin(sinφ1) - asin(χ * sinφ2) + asin(sinφ2))
 end
@@ -285,52 +284,63 @@ vector.
 `Nothing`
 """
 function laplacecoll!(
-        ptype   ::Type{P},
-        dest    ::AbstractVector{T},
-        elements::AbstractVector{Triangle{T}},
-        Ξ       ::AbstractVector{Vector{T}},
-        fvals   ::AbstractVector{T}
-    ) where {T, P <: PotentialType}
+    ptype::Type{<: PotentialType},
+    dest::AbstractVector{T},
+    elements::AbstractVector{Triangle{T}},
+    Ξ::AbstractVector{Vector{T}},
+    fvals::AbstractVector{T}
+) where T
+    tasks = map(index_chunks(Ξ; n = Threads.nthreads(), minsize = 100)) do idx
+        Threads.@spawn _laplacecoll!(ptype, view(dest, idx), elements, view(Ξ, idx), fvals)
+    end
+    wait.(tasks)
+    nothing
+end
+
+function _laplacecoll!(
+    ptype::Type{<: PotentialType},
+    dest::AbstractVector{T},
+    elements::AbstractVector{Triangle{T}},
+    Ξ::AbstractVector{Vector{T}},
+    fvals::AbstractVector{T}
+) where T
     @assert length(dest) == length(Ξ)
     @assert length(fvals) == length(elements)
 
-    ξ = Vector{T}(undef, 3)
-    dat = Vector{T}(undef, 9)
-    @inbounds for eidx in eachindex(elements)
-        elem = elements[eidx]
-        for oidx in eachindex(Ξ)
-            dist = distance(Ξ[oidx], elem)
-            ξ .= Ξ[oidx]
-
-            # project ξ onto elem
-            abs(dist) >= _etol(T) && _projectξ!(ξ, elem, dist)
-
-            dest[oidx] += laplacepot(ptype, ξ, elem, dist; dat=dat) * fvals[eidx]
+    dat = Vector{T}(undef, 12)
+    @inbounds for (oidx, ξ) in enumerate(Ξ)
+        for (eidx, elem) in enumerate(elements)
+            dest[oidx] += laplacecoll(ptype, ξ, elem; dat) * fvals[eidx]
         end
     end
     nothing
 end
 
 function laplacecoll!(
-        ptype   ::Type{P},
-        dest    ::AbstractMatrix{T},
-        elements::AbstractVector{Triangle{T}},
-        Ξ       ::AbstractVector{Vector{T}},
-    ) where {T, P <: PotentialType}
+    ptype::Type{<: PotentialType},
+    dest::AbstractMatrix{T},
+    elements::AbstractVector{Triangle{T}},
+    Ξ::AbstractVector{Vector{T}}
+) where T
+    tasks = map(index_chunks(Ξ; n = Threads.nthreads(), minsize = 100)) do idx
+        Threads.@spawn _laplacecoll!(ptype, view(dest, idx, :), elements, view(Ξ, idx))
+    end
+    wait.(tasks)
+    nothing
+end
+
+function _laplacecoll!(
+    ptype::Type{<: PotentialType},
+    dest::AbstractMatrix{T},
+    elements::AbstractVector{Triangle{T}},
+    Ξ::AbstractVector{Vector{T}}
+) where T
     @assert size(dest) == (length(Ξ), length(elements))
 
-    ξ = Vector{T}(undef, 3)
-    dat = Vector{T}(undef, 9)
-    @inbounds for eidx in eachindex(elements)
-        elem = elements[eidx]
-        for oidx in eachindex(Ξ)
-            dist = distance(Ξ[oidx], elem)
-            ξ .= Ξ[oidx]
-
-            # project ξ onto elem
-            abs(dist) >= _etol(T) && _projectξ!(ξ, elem, dist)
-
-            dest[oidx, eidx] = laplacepot(ptype, ξ, elem, dist; dat=dat)
+    dat = Vector{T}(undef, 12)
+    @inbounds for (eidx, elem) in enumerate(elements)
+        for (oidx, ξ) in enumerate(Ξ)
+            dest[oidx, eidx] = laplacecoll(ptype, ξ, elem; dat)
         end
     end
     nothing
@@ -360,12 +370,11 @@ and observation point `ξ` [[Rja90]](@ref Bibliography).
 `T`
 """
 function laplacecoll(
-        ptype::Type{P},
-        ξ    ::AbstractVector{T},
-        elem ::Triangle{T};
-        dat  ::AbstractVector{T} = Vector{T}(undef, 12)
-    ) where {T, P <: PotentialType}
-
+    ptype::Type{<: PotentialType},
+    ξ::AbstractVector{T},
+    elem::Triangle{T};
+    dat::AbstractVector{T} = Vector{T}(undef, 12)
+) where T
     dist = distance(ξ, elem)
     ξ_p = view(dat, 1:3)
     ξ_p .= ξ
@@ -373,7 +382,7 @@ function laplacecoll(
     # project ξ onto elem
     abs(dist) >= _etol(T) && _projectξ!(ξ_p, elem, dist)
 
-    laplacepot(ptype, ξ_p, elem, dist; dat=view(dat, 4:12))
+    _laplacepot(ptype, ξ_p, elem, dist; dat=view(dat, 4:12))
 end
 
 
@@ -410,5 +419,11 @@ Projects ξ onto the surface element plane, overriding its previous coordinates.
 @inline function _projectξ!(ξ::AbstractVector{T}, elem::Triangle{T}, dist::T) where T
     ξ .-= dist .* elem.normal
 end
+
+# =========================================================================================
+# Deprecation
+
+# renamed in v1.5 (unexported but used by CuNESSie's tests)
+@deprecate laplacepot _laplacepot false
 
 end # module

--- a/src/bem/nonlocal.jl
+++ b/src/bem/nonlocal.jl
@@ -13,11 +13,11 @@ Result data of the nonlocal solving process to be used for potential computation
 post-processing, with `Ξ` being the list of observation points, that is, the set of
 triangle centroids.
 """
-@auto_hash_equals struct NonlocalBEMResult{T, E} <: BEMResult{T, E}
+@auto_hash_equals struct NonlocalBEMResult{T, E, A <: AbstractArray{T, 1}} <: BEMResult{T, E}
     model::Model{T, E}
-    u::SubArray{T,1}
-    q::SubArray{T,1}
-    w::SubArray{T,1}
+    u::A
+    q::A
+    w::A
     umol::Vector{T}
     qmol::Vector{T}
 end

--- a/src/bem/post.jl
+++ b/src/bem/post.jl
@@ -206,10 +206,22 @@ function NESSie.rfpotential(
     !isempty(unknown_domains) && error("unknown domains $unknown_domains")
 
     ret = Array{T}(undef, length(Ξ))
-    view(ret, domains .== :Ω) .= rfpotential(:Ω, view(Ξ, domains .== :Ω), bem; kwargs...)
-    view(ret, domains .== :Σ) .= rfpotential(:Σ, view(Ξ, domains .== :Σ), bem; kwargs...)
-    view(ret, domains .== :Γ) .= rfpotential(:Γ, view(Ξ, domains .== :Γ), bem; kwargs...)
+    _rfpotential!(ret, :Ω, Ξ, bem, domains; kwargs...)
+    _rfpotential!(ret, :Σ, Ξ, bem, domains; kwargs...)
+    _rfpotential!(ret, :Γ, Ξ, bem, domains; kwargs...)
     ret
+end
+
+@inline function _rfpotential!(
+    dst::Vector{T},
+    loc::Symbol,
+    Ξ::AbstractVector{Vector{T}},
+    bem::BEMResult{T},
+    domains::Vector{Symbol};
+    kwargs...
+) where T
+    mask = domains .== loc
+    view(dst, mask) .= rfpotential(loc, view(Ξ, mask), bem; kwargs...)
 end
 
 @inline function NESSie.rfpotential(

--- a/test/radon.jl
+++ b/test/radon.jl
@@ -2,37 +2,38 @@
     include("testsetup.jl")
 
     using NESSie.Radon
+    using NESSie.Radon: _regularyukawapot
 
-    @testset "regularyukawapot" begin
+    @testset "_regularyukawapot (SingleLayer)" begin
         for T in testtypes
             # x -> ξ
             x = ones(T, 3)
             yuk = T(7)
-            ret = Radon.regularyukawapot(x, x, yuk)
+            ret = _regularyukawapot(SingleLayer, x, x, yuk)
             @test typeof(ret) == T
             @test ret == -7
             # ξ not in origin (no cancellation)
             ξ = -ones(T, 3)
-            ret = Radon.regularyukawapot(x, ξ, yuk)
+            ret = _regularyukawapot(SingleLayer, x, ξ, yuk)
             @test typeof(ret) == T
             @test ret ≈ T(-0.28867513458631466433435706025773931468027671112178301167202)
             # ξ in origin (no cancellation)
             ξ = zeros(T, 3)
-            ret = Radon.regularyukawapot(x, ξ, yuk)
+            ret = _regularyukawapot(SingleLayer, x, ξ, yuk)
             @test typeof(ret) == T
             @test ret ≈ T(-0.57734713663526745894988668695023080532035174827300561882957)
             # ξ in origin (potential cancellation)
-            ret = Radon.regularyukawapot(T(.001) * x, ξ, yuk)
+            ret = _regularyukawapot(SingleLayer, T(.001) * x, ξ, yuk)
             @test typeof(ret) == T
             @test ret ≈ T(-6.95773573664079611429119468507639364064769481076591007615189)
             # ξ in origin (potential cancellation 2)
-            ret = Radon.regularyukawapot(T(.0001) * x, ξ, yuk)
+            ret = _regularyukawapot(SingleLayer, T(.0001) * x, ξ, yuk)
             @test typeof(ret) == T
             @test ret ≈ (T == Float64 ?
                 -6.99575819000175052904190394524100762244862345273988759731283 :
                 -yuk)
             # ξ in origin (potential cancellation 3)
-            ret = Radon.regularyukawapot(T(.00001) * x, ξ, yuk)
+            ret = _regularyukawapot(SingleLayer, T(.00001) * x, ξ, yuk)
             @test typeof(ret) == T
             @test ret ≈ (T == Float64 ?
                 -6.99957566470162580591945945320355718542304458045960164651420 :
@@ -40,72 +41,41 @@
         end
     end
 
-    @testset "∂ₙregularyukawapot" begin
+    @testset "_regularyukawapot (DoubleLayer)" begin
         for T in testtypes
             # x -> ξ
             x = ones(T, 3)
             n = map(T, [1, 0, 0])
             yuk = T(7)
-            ret = Radon.∂ₙregularyukawapot(x, x, yuk, n)
+            ret = _regularyukawapot(DoubleLayer, x, x, yuk, n)
             @test typeof(ret) == T
             @test ret ≈ T(14.145081595145832)
             # ξ not in origin (no cancellation)
             ξ = -ones(T, 3)
-            ret = Radon.∂ₙregularyukawapot(x, ξ, yuk, n)
+            ret = _regularyukawapot(DoubleLayer, x, ξ, yuk, n)
             @test typeof(ret) == T
             @test ret ≈ T(0.048112522396707305228639137148607498838982054839859863103104)
             # ξ in origin (no cancellation)
             ξ = zeros(T, 3)
-            ret = Radon.∂ₙregularyukawapot(x, ξ, yuk, n)
+            ret = _regularyukawapot(DoubleLayer, x, ξ, yuk, n)
             @test typeof(ret) == T
             @test ret ≈ T(0.192436385477375021033020985138032408973537816345889754008150)
             # ξ in origin (potential cancellation)
-            ret = Radon.∂ₙregularyukawapot(T(.001) * x, ξ, yuk, n)
+            ret = _regularyukawapot(DoubleLayer, T(.001) * x, ξ, yuk, n)
             @test typeof(ret) == T
             @test ret ≈ T(14.03126641709760402264474861719654017225786809145550365963283)
             # ξ in origin (potential cancellation 2)
-            ret = Radon.∂ₙregularyukawapot(T(.0001) * x, ξ, yuk, n)
+            ret = _regularyukawapot(DoubleLayer, T(.0001) * x, ξ, yuk, n)
             @test typeof(ret) == T
             @test ret ≈ (T == Float64 ?
                 14.13365345844970855427401235115544109979343227826364222026794 :
                 yuk^2 / 2 / Float32(√3))
             # ξ in origin (potential cancellation 3)
-            ret = Radon.∂ₙregularyukawapot(T(.00001) * x, ξ, yuk, n)
+            ret = _regularyukawapot(DoubleLayer, T(.00001) * x, ξ, yuk, n)
             @test typeof(ret) == T
             @test ret ≈ (T == Float64 ?
                 14.14393831379399210175378534648974379367907886588210581085651 :
                 yuk^2 / 2 / Float32(√3))
-        end
-    end
-
-    @testset "radoncoll!" begin
-        using NESSie.Radon: radoncoll!
-
-        for T in testtypes
-            elem = [Triangle(zeros(T, 3), T[2, 0, 0], T[0, 2, 0])]
-            # compute triangle area ∫dx
-            res = zeros(T, 1, 1)
-            radoncoll!(res, elem, [zeros(T, 3)], (_, __, ___, ____) -> one(T), zero(T))
-            @test res[1] ≈ 2one(T)
-            # compute prism volume
-            res = zeros(T, 2, 1)
-            radoncoll!(res, elem, [T[0, 0, 4], T[0, 0, 6]], (x, ξ, _, __) -> ξ[3] - x[3], zero(T))
-            @test res[1] ≈ 8one(T)
-            @test res[2] ≈ 12one(T)
-            # compute tetrahedron volume
-            res = zeros(T, 1, 1)
-            radoncoll!(res, elem, [T[0, 0, 2]], (x, ξ, _, __) -> ξ[3] - x[1] - x[2], zero(T))
-            @test res[1] ≈ 4one(T)/3
-            # a slightly more elaborate tetrahedron volume
-            elem = [Triangle(zeros(T, 3), T[3, 0, 0], T[0, 2, 0])]
-            res = zeros(T, 1, 1)
-            radoncoll!(res, elem, [T[0, 0, 6]], (x, ξ, _, __) -> ξ[3] - 2x[1] - 3x[2], zero(T))
-            @test res[1] ≈ 6one(T)
-            # ∫∫6x²-40y dA
-            elem = [Triangle(T[0, 3, 0], T[1, 1, 0], T[5, 3, 0])]
-            res = zeros(T, 1, 1)
-            radoncoll!(res, elem, [zeros(T, 3)], (x, _, __, ___) -> 6*x[1]^2-40x[2], zero(T))
-            @test res[1] ≈ T(-935/3)
         end
     end
 end


### PR DESCRIPTION
These changes affect all of our BLAS-based (i.e., explicit) BEM solvers as well as all post-processors provided by the `BEM` submodule.