### PR TITLE
Backports v1.4.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Aqua = "0.8"
 Distances = "0.7, 0.8, 0.9, 0.10"
-ImplicitArrays = "0.2"
+ImplicitArrays = "0.2, 0.3"
 IterativeSolvers = "0.8, 0.9"
 JSON3 = "1.9"
 LightXML = "0.8.1, 0.9"


### PR DESCRIPTION
 - [x] [CompatHelper: bump compat for ImplicitArrays to 0.3, (keep existing compat)](https://github.com/tkemmer/NESSie.jl/commit/2531d27f52aec98ece96dc3df2a515fdc1100016)